### PR TITLE
Fix plotting bug

### DIFF
--- a/data.py
+++ b/data.py
@@ -20,7 +20,7 @@ from helper_functions import data_by_state, plot_state_data
 
 # Which states to compare my state to
 my_state = 'NM'
-comparison_states = ['NY','WA', 'SD', 'MT']
+comparison_states = ['NY','WA', 'OR', 'MN', 'MD']
 
 # Number of days over which to perform a moving average
 N_avg = 5
@@ -49,7 +49,7 @@ state_info      =   data_by_state(state_info_url)
 # Plot all of the states on one plot
 slopes_by_state = plot_state_data(state_data, state_info, N_avg, N_slope)
 for state, slope in sorted(slopes_by_state.items(), key=lambda x: x[1]):
-    print(state, slope)
+    print(state, slope, state_data[state]['positive'][-1])
 
 # Combine my_state with comparison states and the overall US data
 try:
@@ -59,7 +59,7 @@ except ValueError:
 comparison_states = ['US'] + [my_state] + comparison_states
 
 # Plot a subset of state data
-select_data = {state:data for state, data in state_data.items() if state in comparison_states}
+select_data = {state:state_data[state] for state in comparison_states}
 plot_state_data(select_data, state_info, N_avg, N_slope, labels=True, my_state=my_state)
 
 plt.show()

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -75,6 +75,8 @@ def plot_state_data(data_dict, data_info, N_avg, N_slope, labels=False, my_state
     ax.legend()
     ax.set_yscale('log')
     ax.set_xscale('log')
+    ax.set_ylim(bottom=1.0)
+    ax.set_xlim(left=1.0)
     ax.set_xlabel('Total number of positive cases')
     ax.set_ylabel('Increase in positive cases')
     
@@ -166,7 +168,7 @@ class data_by_state(dict):
                 keys = entries.keys()
             except AttributeError:
                 # There are multiple entries
-                keys = entries[0].keys()
+                keys = entries[-1].keys()
                 # Store the data as a time series for each entry for each state
                 self[state] = dict()
                 for k in keys:


### PR DESCRIPTION
Because the data class was using the first (i.e. earliest) entry to figure out the available information, some keys would be missing since they would only appear later. This was a particular problem with American Samoa, which didn't have a positive field and screwed up the plotting. This should fix the issue by getting the keys from the last entry.

Various other small fixes and tweaks as well.